### PR TITLE
Add -latest to mmark seriesinfo block

### DIFF
--- a/draft-aaron-acme-ari.md
+++ b/draft-aaron-acme-ari.md
@@ -8,7 +8,7 @@ keyword = ["Internet-Draft"]
 
 [seriesInfo]
 name = "Internet-Draft"
-value = "draft-aaron-acme-ari"
+value = "draft-aaron-acme-ari-latest"
 stream = "IETF"
 status = "standard"
 


### PR DESCRIPTION
I don't know mmark very well, but this seems to result in the version number getting put in the XML "properly" (it's not properly, but xml2rfc seems to manage it well enough).