### PR TITLE
Add "this has been renewed" endpoint

### DIFF
--- a/draft-aaron-acme-ari.md
+++ b/draft-aaron-acme-ari.md
@@ -96,7 +96,7 @@ Content-Type: application/json
 
 We define a new resource type, the "`renewalInfo`" resource, as part of the ACME protocol. To request the suggested renewal information for a certificate, the client sends a GET request to a path under the server's `renewalInfo` URL.
 
-The full request URL is computed by concatenating the `renewalInfo` URL from the server's directory with a forward slash and the base64url-encoding [@!RFC4648, see, section 5] of the bytes of the DER encoding of a CertID ASN.1 sequence [@!RFC6960, see, section 4.1.1]. Trailing '=' characters MUST be stripped.
+The full request URL is computed by concatenating the `renewalInfo` URL from the server's directory with a forward slash and the base64url-encoded [@!RFC4648, section 5] bytes of a DER-encoded `CertID` ASN.1 sequence [@!RFC6960, section 4.1.1]. Trailing '=' characters MUST be stripped.
 
 For example, to request renewal information for the certificate given in Appendix A.1, issued by the CA given in Appendix A.2, using SHA256, the client would make the following request (the path has been split onto multiple lines for readability):
 

--- a/draft-aaron-acme-ari.md
+++ b/draft-aaron-acme-ari.md
@@ -96,20 +96,18 @@ Content-Type: application/json
 
 We define a new resource type, the "`renewalInfo`" resource, as part of the ACME protocol. To request the suggested renewal information for a certificate, the client sends a GET request to a path under the server's `renewalInfo` URL.
 
-The full request URL is computed by concatenating the `renewalInfo` URL from the server's directory with the following case-insensitive hex-encoded (see [@!RFC4648], Section [@!RFC4648, section 8]) elements, separated by forward slashes:
+The full request URL is computed by concatenating the `renewalInfo` URL from the server's directory with a forward slash and the base64url-encoding [@!RFC4648, see, section 5] of the bytes of the DER encoding of a CertID ASN.1 sequence [@!RFC6960, see, section 4.1.1]. Trailing '=' characters MUST be stripped.
 
-* the SHA-1 hash of the issuer's public key (often included in the certificate as the Authority Key Identifier, see [@!RFC5280], Section [@!RFC5280, section 4.2.1.1]),
-* the SHA-1 hash of the issuer's Distinguished Name, see [@!RFC5280], Section [@!RFC5280, section 4.1.2.4], and
-* the certificate serial number.
-
-These are the same components that make up the `CertID` sequence of an `OCSPRequest` [@!RFC6960], Section [@RFC6960, section 4.1.1], with the caveat that the hash algorithm is restricted to SHA-1, in line with [@!RFC5019].
+For example, to request renewal information for the certificate given in Appendix A.1, issued by the CA given in Appendix A.2, using SHA256, the client would make the following request (the path has been split onto multiple lines for readability):
 
 ~~~ text
-GET https://example.com/acme/renewal-info
-        /254581685026383D3B2D2CBECD6AD9B63DB36663
-        /06FE0BABD8E6746EFCC4730285F7A9487ED1344F
-        /BCDF4596B6BDC523
+GET https://example.com/acme/renewal-info/
+        MFswCwYJYIZIAWUDBAIBBCCeWLRusNLb--vmWOkxm34qDjTMWkc
+        3utIhOMoMwKDqbgQg2iiKWySZrD-6c88HMZ6vhIHZPamChLlzGH
+        eZ7pTS8jYCCD6jRWhlRB8c
 ~~~
+
+The ACME Server **MAY** restrict the hash algorithms which it accepts (for example, only allowing SHA256 to limit the number of potential cache keys); if it receives a request whose embedded `signatureAlgorithm` field contains an unacceptable OID, it **SHOULD** respond with an HTTP 400 status code.
 
 The structure of an ACME `renewalInfo` resource is as follows:
 
@@ -175,6 +173,61 @@ Field Name      | Field type | Reference
 suggestedWindow | object     | This draft
 
 {backmatter}
+
+{numbered="false"}
+# Appendix A. Example Certificates
+
+{numbered="false"}
+## A.1. Example End-Entity Certificate
+
+~~~ text
+-----BEGIN CERTIFICATE-----
+MIIDMDCCAhigAwIBAgIIPqNFaGVEHxwwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
+AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MB4XDTIyMDMxNzE3NTEwOVoXDTI0MDQx
+NjE3NTEwOVowFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCgm9K/c+il2Pf0f8qhgxn9SKqXq88cOm9ov9AVRbPA
+OWAAewqX2yUAwI4LZBGEgzGzTATkiXfoJ3cN3k39cH6tBbb3iSPuEn7OZpIk9D+e
+3Q9/hX+N/jlWkaTB/FNA+7aE5IVWhmdczYilXa10V9r+RcvACJt0gsipBZVJ4jfJ
+HnWJJGRZzzxqG/xkQmpXxZO7nOPFc8SxYKWdfcgp+rjR2ogYhSz7BfKoVakGPbpX
+vZOuT9z4kkHra/WjwlkQhtHoTXdAxH3qC2UjMzO57Tx+otj0CxAv9O7CTJXISywB
+vEVcmTSZkHS3eZtvvIwPx7I30ITRkYk/tLl1MbyB3SiZAgMBAAGjeDB2MA4GA1Ud
+DwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0T
+AQH/BAIwADAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTAWBgNVHREE
+DzANggtleGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEAx0aYvmCk7JYGNEXe
++hrOfKawkHYzWvA92cI/Oi6h+oSdHZ2UKzwFNf37cVKZ37FCrrv5pFP/xhhHvrNV
+EnOx4IaF7OrnaTu5miZiUWuvRQP7ZGmGNFYbLTEF6/dj+WqyYdVaWzxRqHFu1ptC
+TXysJCeyiGnR+KOOjOOQ9ZlO5JUK3OE4hagPLfaIpDDy6RXQt3ss0iNLuB1+IOtp
+1URpvffLZQ8xPsEgOZyPWOcabTwJrtqBwily+lwPFn2mChUx846LwQfxtsXU/lJg
+HX2RteNJx7YYNeX3Uf960mgo5an6vE8QNAsIoNHYrGyEmXDhTRe9mCHyiW2S7fZq
+o9q12g==
+-----END CERTIFICATE-----
+~~~
+
+{numbered="false"}
+## Example CA Certificate
+
+~~~ text
+-----BEGIN CERTIFICATE-----
+MIIDSzCCAjOgAwIBAgIIOhNWtJ7Igr0wDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
+AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MCAXDTIyMDMxNzE3NTEwOVoYDzIxMjIw
+MzE3MTc1MTA5WjAgMR4wHAYDVQQDExVtaW5pY2Egcm9vdCBjYSAzYTEzNTYwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDc3P6cxcCZ7FQOQrYuigReSa8T
+IOPNKmlmX9OrTkPwjThiMNEETYKO1ea99yXPK36LUHC6OLmZ9jVQW2Ny1qwQCOy6
+TrquhnwKgtkBMDAZBLySSEXYdKL3r0jA4sflW130/OLwhstU/yv0J8+pj7eSVOR3
+zJBnYd1AqnXHRSwQm299KXgqema7uwsa8cgjrXsBzAhrwrvYlVhpWFSv3lQRDFQg
+c5Z/ZDV9i26qiaJsCCmdisJZWN7N2luUgxdRqzZ4Cr2Xoilg3T+hkb2y/d6ttsPA
+kaSA+pq3q6Qa7/qfGdT5WuUkcHpvKNRWqnwT9rCYlmG00r3hGgc42D/z1VvfAgMB
+AAGjgYYwgYMwDgYDVR0PAQH/BAQDAgKEMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggr
+BgEFBQcDAjASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBQ4zzDRUaXHVKql
+STWkULGU4zGZpTAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTANBgkq
+hkiG9w0BAQsFAAOCAQEArbDHhEjGedjb/YjU80aFTPWOMRjgyfQaPPgyxwX6Dsid
+1i2H1x4ud4ntz3sTZZxdQIrOqtlIWTWVCjpStwGxaC+38SdreiTTwy/nikXGa/6W
+ZyQRppR3agh/pl5LHVO6GsJz3YHa7wQhEhj3xsRwa9VrRXgHbLGbPOFVRTHPjaPg
+Gtsv2PN3f67DsPHF47ASqyOIRpLZPQmZIw6D3isJwfl+8CzvlB1veO0Q3uh08IJc
+fspYQXvFBzYa64uKxNAJMi4Pby8cf4r36Wnb7cL4ho3fOHgAltxdW8jgibRzqZpQ
+QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
+-----END CERTIFICATE-----
+~~~
 
 {numbered="false"}
 # Acknowledgments

--- a/draft-aaron-acme-ari.md
+++ b/draft-aaron-acme-ari.md
@@ -102,7 +102,7 @@ To request the suggested renewal information for a certificate, the client sends
 
 The full request URL is computed by concatenating the `renewalInfo` URL from the server's directory with a forward slash and the base64url-encoded [@!RFC4648, section 5] bytes of a DER-encoded `CertID` ASN.1 sequence [@!RFC6960, section 4.1.1]. Trailing '=' characters MUST be stripped.
 
-For example, to request renewal information for the end-entity certificate given in Appendix A.1, issued by the intermediate certificate given in Appendix A.2, using SHA256, the client would make the following request (the path has been split onto multiple lines for readability):
+For example, to request renewal information for the end-entity certificate given in Appendix A.1, issued by the CA certificate given in Appendix A.2, using SHA256, the client would make the following request (the path has been split onto multiple lines for readability):
 
 ~~~ text
 GET https://example.com/acme/renewal-info/

--- a/draft-aaron-acme-ari.md
+++ b/draft-aaron-acme-ari.md
@@ -94,7 +94,7 @@ Content-Type: application/json
 
 # Extensions to the ACME Protocol: The "renewalInfo" Resource
 
-We define a new resource type, the "`renewalInfo`" resource, as part of the ACME protocol. This new resource both allows clients to query the server for suggestions on when they should renew certificates, and allows clients to inform the server when they have completed renewal (or otherwise replaced the certificate to their satisfaction).
+The "`renewalInfo`" resource is a new resource type introduced to ACME protocol. This new resource both allows clients to query the server for suggestions on when they should renew certificates, and allows clients to inform the server when they have completed renewal (or otherwise replaced the certificate to their satisfaction).
 
 ## Getting Renewal Information
 
@@ -102,7 +102,7 @@ To request the suggested renewal information for a certificate, the client sends
 
 The full request URL is computed by concatenating the `renewalInfo` URL from the server's directory with a forward slash and the base64url-encoded [@!RFC4648, section 5] bytes of a DER-encoded `CertID` ASN.1 sequence [@!RFC6960, section 4.1.1]. Trailing '=' characters MUST be stripped.
 
-For example, to request renewal information for the certificate given in Appendix A.1, issued by the CA given in Appendix A.2, using SHA256, the client would make the following request (the path has been split onto multiple lines for readability):
+For example, to request renewal information for the end-entity certificate given in Appendix A.1, issued by the intermediate certificate given in Appendix A.2, using SHA256, the client would make the following request (the path has been split onto multiple lines for readability):
 
 ~~~ text
 GET https://example.com/acme/renewal-info/
@@ -111,7 +111,7 @@ GET https://example.com/acme/renewal-info/
         eZ7pTS8jYCCD6jRWhlRB8c
 ~~~
 
-The ACME Server **MAY** restrict the hash algorithms which it accepts (for example, only allowing SHA256 to limit the number of potential cache keys); if it receives a request whose embedded `signatureAlgorithm` field contains an unacceptable OID, it **SHOULD** respond with an HTTP 400 status code.
+The ACME Server **MAY** restrict the hash algorithms which it accepts (for example, only allowing SHA256 to limit the number of potential cache keys); if it receives a request whose embedded `signatureAlgorithm` field contains an unacceptable OID, it **SHOULD** respond with HTTP status code 400 (Bad Request).
 
 The structure of an ACME `renewalInfo` resource is as follows:
 
@@ -140,13 +140,13 @@ If the client receives no response or a malformed response (e.g. an `end` timest
 
 ## Updating Renewal Information
 
-To update the renewal status of a certificate, the client sends a POST-as-GET request to the server's `renewalInfo` URL.
+To update the renewal status of a certificate, the client sends a POST request to the server's `renewalInfo` URL.
 
-The body of the POST is a JWS object whose JSON payload contains the `CertID` of the certificate in question:
+The body of the POST is a JWS object which is authenticated to an account as defined in [@!RFC8555], Section 6.2, and whose JSON payload has the following structure:
 
 certID (required, string): The `CertID` of the certificate whose renewal information should be updated, in the base64url-encoded version of the DER format with trailing "=" stripped. Note: this is identical to the final path component constructed for GET requests above.
 
-replaced (required, boolean): Whether or not the certificate has been replaced. Clients SHOULD NOT send a request where this value is false.
+replaced (required, boolean): Whether or not the client considers the certificate to have been replaced. A certificate is considered replaced when its revocation would not disrupt any ongoing services, for instance because it has been renewed and the new certificate is in use, or because it is no longer in use. Clients SHOULD NOT send a request where this value is false.
 
 ~~~ text
 POST /acme/renewal-info HTTP/1.1
@@ -168,13 +168,13 @@ Content-Type: application/jose+json
 }
 ~~~
 
-The server MUST verify that the request is signed by the account key of the Subscriber to which the certificate was originally issued. If the server accepts the request and the update succeeds, it responds with status code 200 (OK). If the update is rejected or fails, for example because the certificate has already been marked as renewed, the server returns an error.
+The server MUST verify that the request is signed by the account key of the Subscriber to which the certificate was originally issued. If the server accepts the request and the update succeeds, it responds with HTTP status code 200 (OK). If the update is rejected or fails, for example because the certificate has already been marked as replaced, the server returns an error.
 
 The server might use this renewal update to inform a number of processes, such as: not sending renewal reminder notifications for certificates that have been marked as replaced; sending empty or error responses to subsequent requests for the certificate's renewal information; or confidently revoking certificates subject to a mass revocation without fear of disrupting the Subscriber's operations.
 
 # Security Considerations
 
-The extensions to the ACME protocol described in this document build upon the Security Considerations and threat model defined in [@!RFC8555], Section [@!RFC8555, section 10.1].
+The extensions to the ACME protocol described in this document build upon the Security Considerations and threat model defined in [@!RFC8555], Section Section 10.1.
 
 This document specifies that `renewalInfo` resources **MUST** be exposed and accessed via unauthenticated GET requests, a departure from RFC8555’s requirement that clients must send POST-as-GET requests to fetch resources from the server. This is because the information contained in `renewalInfo` resources is not considered confidential, and because allowing `renewalInfo` to be easily cached is advantageous to shed load from clients which do not respect the Retry-After header.
 


### PR DESCRIPTION
Add a specification for POST behavior at the renewalInfo
resource, so that clients can inform the server when they have
completed renewal/replacement of a certificate.

Fixes #15